### PR TITLE
Correct possible hangs.

### DIFF
--- a/proxy.c
+++ b/proxy.c
@@ -265,9 +265,9 @@ void forward_data(int source_sock, int destination_sock) {
         exit(EXIT_FAILURE);
     }
 
-    while ((n = splice(source_sock, NULL, buf_pipe[WRITE], NULL, BUF_SIZE, SPLICE_F_MOVE)) > 0) {
-        if (splice(buf_pipe[READ], NULL, destination_sock, NULL, n, SPLICE_F_MOVE) < 0) {
-            perror("splice");
+    while ((n = splice(source_sock, NULL, buf_pipe[WRITE], NULL, SSIZE_MAX, SPLICE_F_NONBLOCK|SPLICE_F_MOVE)) > 0) {
+        if (splice(buf_pipe[READ], NULL, destination_sock, NULL, SSIZE_MAX, SPLICE_F_MOVE) < 0) {
+            perror("write");
             exit(EXIT_FAILURE);
         }
     }
@@ -278,6 +278,9 @@ void forward_data(int source_sock, int destination_sock) {
         send(destination_sock, buffer, n, 0); // send data to output socket
     }
 #endif
+
+    if (n < 0)
+        perror("read");
 
 #ifdef USE_SPLICE
     close(buf_pipe[0]);

--- a/proxy.c
+++ b/proxy.c
@@ -190,7 +190,6 @@ void update_connection_count()
 /* Handle finished child process */
 void sigchld_handler(int signal) {
     while (waitpid(-1, NULL, WNOHANG) > 0);
-    update_connection_count();
 }
 
 /* Handle term signal */

--- a/proxy.c
+++ b/proxy.c
@@ -359,3 +359,4 @@ int create_connection() {
 
     return sock;
 }
+/* vim: set et ts=4 sw=4: */


### PR DESCRIPTION
First commit is an update to pull request #3, sd_notifyf calls sprintf which calls malloc, this can cause a deadlock when called while ptmalloc has not unlocked yet. Since a child handler can be called anytime, it can cause a race condition.

Second commit is a fix for pull request #2, the splice call that writes to the socket can return a that a write was shorter than requested, in that case, the first splice may block indefinitely since the remote side of the socket is expecting more data before continuing. To fix this, the first call to splice will never block and will try to stuff as much as possible in the kernel pipe, then the second call to splice will use SSIZE_MAX to write as much as possible from the pipe, if we use n, we might have some data always lingering in the pipe since the last call did a short write and n may be less than what remains in the pipe.

The last commit is just a modeline for VIM since the code is indented with space instead of tabs.