### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcc
+
+WORKDIR /usr/src/app/
+COPY . /usr/src/app/
+
+RUN make
+
+ENTRYPOINT [ "./proxy", "-f" ]


### PR DESCRIPTION
As I've started to tinker with `proxy`, I'd like to share the `Dockerfile` which enabled a Docker workflow for me.

Add `Dockerfile` to enable image building. Useful for development and tests under Docker workflow.
Using the official GCC image, latest tag. More info at https://hub.docker.com/_/gcc/
 
Just adding files, setting working dir and running install and build instructions.
 
Build:
```
$ docker build -t proxy .
```
 
Run:
```
$ docker run --rm -it  -p 80:80 proxy -b 0.0.0.0 -l 80 ...
```
 
The example maps container's internal port 80 to outside host (`-p`). Adding `0.0.0.0` is required, since otherwise container's `localhost` would not be reachable from outside (the host). 
Using `--rm` causes container it to be deleted after stop and `-it` makes the container not to go background and run interactively. Stop by `CTRL+C`'ing.